### PR TITLE
Fixes for esp32

### DIFF
--- a/src/tensorflow/lite/micro/memory_planner/greedy_memory_planner.h
+++ b/src/tensorflow/lite/micro/memory_planner/greedy_memory_planner.h
@@ -156,7 +156,7 @@ class GreedyMemoryPlanner : public MicroMemoryPlanner {
 
   // Whether buffers have been added since the last plan was calculated.
   bool need_to_calculate_offsets_;
-
+public:
   TF_LITE_REMOVE_VIRTUAL_DELETE
 };
 

--- a/src/tensorflow/lite/micro/system_ArduinoRingBuffer.h
+++ b/src/tensorflow/lite/micro/system_ArduinoRingBuffer.h
@@ -1,0 +1,142 @@
+/*
+  RingBuffer.h - Ring buffer implementation
+  Copyright (c) 2014 Arduino.  All right reserved.
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#ifdef __cplusplus
+
+#ifndef _RING_BUFFER_
+#define _RING_BUFFER_
+
+#include <stdint.h>
+#include <string.h>
+
+namespace arduino {
+
+// Define constants and variables for buffering incoming serial data.  We're
+// using a ring buffer (I think), in which head is the index of the location
+// to which to write the next incoming character and tail is the index of the
+// location from which to read.
+#define SERIAL_BUFFER_SIZE 64
+
+template <int N>
+class RingBufferN
+{
+  public:
+    uint8_t _aucBuffer[N] ;
+    volatile int _iHead ;
+    volatile int _iTail ;
+    volatile int _numElems;
+
+  public:
+    RingBufferN( void ) ;
+    void store_char( uint8_t c ) ;
+    void clear();
+    int read_char();
+    int available();
+    int availableForStore();
+    int peek();
+    bool isFull();
+
+  private:
+    int nextIndex(int index);
+    inline bool isEmpty() const { return (_numElems == 0); }
+};
+
+typedef RingBufferN<SERIAL_BUFFER_SIZE> RingBuffer;
+
+
+template <int N>
+RingBufferN<N>::RingBufferN( void )
+{
+    memset( _aucBuffer, 0, N ) ;
+    clear();
+}
+
+template <int N>
+void RingBufferN<N>::store_char( uint8_t c )
+{
+  // if we should be storing the received character into the location
+  // just before the tail (meaning that the head would advance to the
+  // current location of the tail), we're about to overflow the buffer
+  // and so we don't write the character or advance the head.
+  if (!isFull())
+  {
+    _aucBuffer[_iHead] = c ;
+    _iHead = nextIndex(_iHead);
+    _numElems = _numElems + 1;
+  }
+}
+
+template <int N>
+void RingBufferN<N>::clear()
+{
+  _iHead = 0;
+  _iTail = 0;
+  _numElems = 0;
+}
+
+template <int N>
+int RingBufferN<N>::read_char()
+{
+  if (isEmpty())
+    return -1;
+
+  uint8_t value = _aucBuffer[_iTail];
+  _iTail = nextIndex(_iTail);
+  _numElems = _numElems - 1;
+
+  return value;
+}
+
+template <int N>
+int RingBufferN<N>::available()
+{
+  return _numElems;
+}
+
+template <int N>
+int RingBufferN<N>::availableForStore()
+{
+  return (N - _numElems);
+}
+
+template <int N>
+int RingBufferN<N>::peek()
+{
+  if (isEmpty())
+    return -1;
+
+  return _aucBuffer[_iTail];
+}
+
+template <int N>
+int RingBufferN<N>::nextIndex(int index)
+{
+  return (uint32_t)(index + 1) % N;
+}
+
+template <int N>
+bool RingBufferN<N>::isFull()
+{
+  return (_numElems == N);
+}
+
+}
+
+#endif /* _RING_BUFFER_ */
+#endif /* __cplusplus */

--- a/src/tensorflow/lite/micro/system_setup.cpp
+++ b/src/tensorflow/lite/micro/system_setup.cpp
@@ -23,6 +23,11 @@ limitations under the License.
 
 #include "Arduino.h"
 
+#ifndef ARDUINO_ARCH_MBED
+#include "system_ArduinoRingBuffer.h"
+using namespace arduino;
+#endif
+
 // The Arduino DUE uses a different object for the default serial port shown in
 // the monitor than most other models, so make sure we pick the right one. See
 // https://github.com/arduino/Arduino/issues/3088#issuecomment-406655244

--- a/src/tensorflow/lite/micro/tflite_bridge/micro_error_reporter.h
+++ b/src/tensorflow/lite/micro/tflite_bridge/micro_error_reporter.h
@@ -28,7 +28,6 @@ class MicroErrorReporter : public ErrorReporter {
   ~MicroErrorReporter() override {}
   int Report(const char* format, va_list args) override;
 
- private:
   TF_LITE_REMOVE_VIRTUAL_DELETE
 };
 


### PR DESCRIPTION
The only things preventing this to run + compile for ESP32 are two issues about private destructors or delete operators (weird ??) and the usage of `RingBuffer.h` which does not exist in the Arduino-ESP32 core, which can however be easily copied from the original source <https://github.com/arduino/ArduinoCore-API/blob/master/api/RingBuffer.h>. So I include it for all boards not using <https://github.com/arduino/ArduinoCore-mbed>.

The hello-world example then seems to be running.

```
--- Terminal on COM4 | 115200 8-N-1
--- Available filters and text transformations: colorize, debug, default, direct, esp32_exception_decoder, hexlify, log2file, nocontrol, printable, send_on_enter, time
--- More details at https://bit.ly/pio-monitor-filters
--- Quit: Ctrl+C | Menu: Ctrl+T | Help: Ctrl+T followed by Ctrl+H
ets Jun  8 2016 00:22:57

rst:0x10 (RTCWDT_RTC_RESET),boot:0x13 (SPI_FAST_FLASH_BOOT)
configsip: 0, SPIWP:0xee
clk_drv:0x00,q_drv:0x00,d_drv:0x00,cs0_drv:0x00,hd_drv:0x00,wp_drv:0x00
mode:DIO, clock div:2
load:0x3fff0030,len:1184
load:0x40078000,len:13232
load:0x40080400,len:3028
entry 0x400805e4
Sine(x) function inference example.
Initializing TensorFlow Lite Micro Interpreter...
Initialization done.

Please, input a float number between 0 and 6.28
1.3
Your input value: 1.30
Adapted input value: 1.30
Inferred Sin of 1.30 = 0.97
Actual Sin of 1.30 = 0.96
```